### PR TITLE
Enable OIDC by default

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,4 +10,7 @@ quarkus.http.port=8080
 quarkus.http.host=0.0.0.0
 
 # OIDC Configuration
-quarkus.oidc.enabled=false
+quarkus.oidc.enabled=true
+quarkus.oidc.auth-server-url=https://localhost:8443/realms/qtodo
+quarkus.oidc.client-id=qtodo
+quarkus.oidc.application-type=web-app


### PR DESCRIPTION
Enable OIDC by default. Since no authorization policy is in place, it will not restrict access to the application. An error will appear at startup, but will not be a critical failure and application will start up without issue