### PR TITLE
Change version

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi10/ubi-minimal:10.0-1754585875
 
 ARG version=1.0.0
-ARG artifact=qtodo-$version-SNAPSHOT-runner.jar
+ARG artifact=qtodo-$version-runner.jar
 
 # Maintainer information
 LABEL maintainer="Zero Trust Validated Patterns Team <ztvp-arch-group@redhat.com>" \

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.fictional</groupId>
     <artifactId>qtodo</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
 
     <properties>
         <compiler-plugin.version>3.14.0</compiler-plugin.version>


### PR DESCRIPTION
This PR changes the version of **qtodo** to 1.0.0 and adds a target to the `Makefile` to extract the version.

The change in the default value of the VERSION variable is a bit tricky. The Maven wrapper can be a little slow (though more reliable), and this would be executed every time the `Makefile` is used. It will improve overall response time when using `make`.