### PR TITLE
Add client_id to Azure Entra ID token exchange requests

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi10/ubi-minimal:10.0-1754585875
 
-ARG version=1.0.0
+ARG version=1.0.1
 ARG artifact=qtodo-$version-runner.jar
 
 # Maintainer information

--- a/Containerfile.build
+++ b/Containerfile.build
@@ -24,7 +24,7 @@ FROM registry.access.redhat.com/ubi10/ubi-minimal:10.0-1754585875 AS runtime
 # Maintainer information
 LABEL maintainer="Zero Trust Validated Patterns Team <ztvp-arch-group@redhat.com>" \
       description="QTodo - Persistent Web Todo Application" \
-      version="1.0.0" \
+      version="1.0.1" \
       io.openshift.tags="quarkus,java,web,pattern" \
       io.openshift.expose-services="8080:http" \
       io.k8s.description="Persistent Web Todo application built with Quarkus" \

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,9 @@
                         <phase>initialize</phase>
                     </execution>
                 </executions>
+                <configuration>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.fictional</groupId>
     <artifactId>qtodo</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 
     <properties>
         <compiler-plugin.version>3.14.0</compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,26 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>9.0.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>

--- a/src/main/java/org/fictional/qtodo/AppLifecycle.java
+++ b/src/main/java/org/fictional/qtodo/AppLifecycle.java
@@ -1,0 +1,25 @@
+package org.fictional.qtodo;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.StartupEvent;
+
+@ApplicationScoped
+public class AppLifecycle {
+
+    private static final Logger LOG = Logger.getLogger(AppLifecycle.class);
+
+    @ConfigProperty(name = "app.version", defaultValue = "unknown")
+    String appVersion;
+
+    @ConfigProperty(name = "app.git-commit", defaultValue = "unknown")
+    String gitCommit;
+
+    void onStart(@Observes StartupEvent ev) {
+        LOG.infof("qtodo version=%s commit=%s", appVersion, gitCommit);
+    }
+}

--- a/src/main/java/org/fictional/qtodo/AzureClientIdRequestFilter.java
+++ b/src/main/java/org/fictional/qtodo/AzureClientIdRequestFilter.java
@@ -1,0 +1,51 @@
+package org.fictional.qtodo;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcRequestFilter;
+
+/**
+ * Workaround for Quarkus OIDC not sending client_id alongside client_assertion
+ * in the token exchange request body.
+ *
+ * Azure Entra ID with federated identity credentials (SPIFFE/SPIRE workload
+ * identity) requires client_id to be present in the token request when
+ * client_assertion is used. Without it, Azure cannot map the federated
+ * credential to the correct app registration and returns AADSTS7000110
+ * ("multiple application identifiers found").
+ *
+ * In Quarkus 3.20.x OidcProviderClientImpl, the jwt-bearer authentication
+ * branch only adds client_assertion and client_assertion_type but skips
+ * client_id. This filter appends it to the encoded form body.
+ */
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(OidcEndpoint.Type.TOKEN)
+public class AzureClientIdRequestFilter implements OidcRequestFilter {
+
+    private static final Logger LOG = Logger.getLogger(AzureClientIdRequestFilter.class);
+
+    @ConfigProperty(name = "quarkus.oidc.client-id")
+    String clientId;
+
+    @Override
+    public void filter(OidcRequestContext requestContext) {
+        if (requestContext.requestBody() == null) {
+            return;
+        }
+        String body = requestContext.requestBody().toString();
+        if (body.contains("client_assertion=") && !body.contains("client_id=")) {
+            String encoded = URLEncoder.encode(clientId, StandardCharsets.UTF_8);
+            requestContext.requestBody().appendString("&client_id=" + encoded);
+            LOG.info("Injected client_id into token request for Azure federated credential authentication");
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,7 @@ quarkus.oidc.enabled=true
 quarkus.oidc.auth-server-url=https://localhost:8443/realms/qtodo
 quarkus.oidc.client-id=qtodo
 quarkus.oidc.application-type=web-app
+
+# Application info (populated at build time via Maven resource filtering)
+app.version=${project.version}
+app.git-commit=${git.commit.id.abbrev}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,4 +17,4 @@ quarkus.oidc.application-type=web-app
 
 # Application info (populated at build time via Maven resource filtering)
 app.version=${project.version}
-app.git-commit=${git.commit.id.abbrev}
+app.git-commit=${git.commit.id.abbrev:unknown}


### PR DESCRIPTION
This PR fixes Azure Entra ID login when using SPIFFE/SPIRE workload identity for client authentication.

Quarkus 3.20 omits `client_id` from the token exchange request when `quarkus.oidc.credentials.jwt.source=bearer` is configured. Azure Entra ID then returns `AADSTS7000110` because it cannot match the federated credential to the app registration.

This PR adds:

- An `OidcRequestFilter` that injects `client_id` into token requests when a `client_assertion` is present
- `@Unremovable` on the filter so Quarkus does not remove it at build time
- A startup log with application version and git commit to make it easier to confirm the running build