### PR TITLE
Fix Maven resource filtering breaking todo DELETE

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi10/ubi-minimal:10.0-1754585875
 
-ARG version=1.0.1
+ARG version=1.0.2
 ARG artifact=qtodo-$version-runner.jar
 
 # Maintainer information

--- a/Containerfile.build
+++ b/Containerfile.build
@@ -24,7 +24,7 @@ FROM registry.access.redhat.com/ubi10/ubi-minimal:10.0-1754585875 AS runtime
 # Maintainer information
 LABEL maintainer="Zero Trust Validated Patterns Team <ztvp-arch-group@redhat.com>" \
       description="QTodo - Persistent Web Todo Application" \
-      version="1.0.1" \
+      version="1.0.2" \
       io.openshift.tags="quarkus,java,web,pattern" \
       io.openshift.expose-services="8080:http" \
       io.k8s.description="Persistent Web Todo application built with Quarkus" \

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.fictional</groupId>
     <artifactId>qtodo</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <properties>
         <compiler-plugin.version>3.14.0</compiler-plugin.version>
@@ -67,9 +67,20 @@
 
     <build>
         <resources>
+            <!-- Filter only properties so JS template literals like ${id} in HTML are preserved -->
             <resource>
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
+                <includes>
+                    <include>**/application.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>**/application.properties</exclude>
+                </excludes>
             </resource>
         </resources>
         <plugins>


### PR DESCRIPTION
Limit Maven resource filtering to `application.properties` so JS template literals in `index.html` (e.g. `${id}`) are no longer replaced at build time. This was turning `DELETE /api/todos/${id}` into a hardcoded Maven GAV (`org.fictional:qtodo:jar:…`), which made every delete return 404.

Bump version to 1.0.2

## Test plan

* [ ] Rebuild the image. You can do it using the **supply-chain** feature and the following arguments:
  ```shell
  git-url: https://github.com/mlorenzofr/qtodo.git
  git-revision: fix-pom-filtering
  ```
* [ ] Check that the version and commit (unknown) are correctly resolved in the logs of the qtodo application.
* [ ] Open the application, add a todo, delete it, and verify.