### PR TITLE
Rename AzureClientIdRequestFilter to ClientIdRequestFilter

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi10/ubi-minimal:10.0-1754585875
 
-ARG version=1.0.2
+ARG version=1.0.3
 ARG artifact=qtodo-$version-runner.jar
 
 # Maintainer information

--- a/Containerfile.build
+++ b/Containerfile.build
@@ -24,7 +24,7 @@ FROM registry.access.redhat.com/ubi10/ubi-minimal:10.0-1754585875 AS runtime
 # Maintainer information
 LABEL maintainer="Zero Trust Validated Patterns Team <ztvp-arch-group@redhat.com>" \
       description="QTodo - Persistent Web Todo Application" \
-      version="1.0.2" \
+      version="1.0.3" \
       io.openshift.tags="quarkus,java,web,pattern" \
       io.openshift.expose-services="8080:http" \
       io.k8s.description="Persistent Web Todo application built with Quarkus" \

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.fictional</groupId>
     <artifactId>qtodo</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
 
     <properties>
         <compiler-plugin.version>3.14.0</compiler-plugin.version>

--- a/src/main/java/org/fictional/qtodo/ClientIdRequestFilter.java
+++ b/src/main/java/org/fictional/qtodo/ClientIdRequestFilter.java
@@ -29,9 +29,9 @@ import io.quarkus.oidc.common.OidcRequestFilter;
 @ApplicationScoped
 @Unremovable
 @OidcEndpoint(OidcEndpoint.Type.TOKEN)
-public class AzureClientIdRequestFilter implements OidcRequestFilter {
+public class ClientIdRequestFilter implements OidcRequestFilter {
 
-    private static final Logger LOG = Logger.getLogger(AzureClientIdRequestFilter.class);
+    private static final Logger LOG = Logger.getLogger(ClientIdRequestFilter.class);
 
     @ConfigProperty(name = "quarkus.oidc.client-id")
     String clientId;
@@ -45,7 +45,7 @@ public class AzureClientIdRequestFilter implements OidcRequestFilter {
         if (body.contains("client_assertion=") && !body.contains("client_id=")) {
             String encoded = URLEncoder.encode(clientId, StandardCharsets.UTF_8);
             requestContext.requestBody().appendString("&client_id=" + encoded);
-            LOG.info("Injected client_id into token request for Azure federated credential authentication");
+            LOG.debug("Injected client_id into token request (mandatory Azure Entra ID)");
         }
     }
 }


### PR DESCRIPTION
* Rename `AzureClientIdRequestFilter` to `ClientIdRequestFilter` for a provider-neutral name
* Demote the `client_id` injection log from info to debug